### PR TITLE
Move io.py into apf

### DIFF
--- a/flyllm/config.py
+++ b/flyllm/config.py
@@ -1,5 +1,12 @@
 import numpy as np
 import re
+import pathlib
+import os
+
+codedir = pathlib.Path(__file__).parent.resolve()
+DEFAULTCONFIGFILE = os.path.join(codedir, 'config_fly_llm_default.json')
+assert os.path.exists(DEFAULTCONFIGFILE), f"{DEFAULTCONFIGFILE} does not exist."
+
 
 # Names of features
 keypointnames = [

--- a/flyllm/features.py
+++ b/flyllm/features.py
@@ -832,6 +832,12 @@ def compute_otherflies_touch_mult(data, prct=99):
     return otherflies_touch_mult
 
 
+def ensure_otherflies_touch_mult(data):
+    if np.isnan(SENSORY_PARAMS['otherflies_touch_mult']):
+        LOG.info('computing touch parameters...')
+        SENSORY_PARAMS['otherflies_touch_mult'] = compute_otherflies_touch_mult(data)
+
+
 def compute_sensory_wrapper(Xkp, flynum, theta_main=None, returnall=False, returnidx=False):
     # other flies positions
     idxother = np.ones(Xkp.shape[-1], dtype=bool)
@@ -1239,24 +1245,3 @@ def compute_noise_params(data, scale_perfly, sig_tracking=.25 / PXPERMM,
     epsilon = np.sqrt(alld / n)
 
     return epsilon.flatten()
-
-
-def compute_scale_allflies(data):
-    maxid = np.max(data['ids'])
-    maxnflies = data['X'].shape[3]
-    scale_perfly = None
-
-    for flynum in range(maxnflies):
-
-        idscurr = np.unique(data['ids'][data['ids'][:, flynum] >= 0, flynum])
-        for id in idscurr:
-            idx = data['ids'][:, flynum] == id
-            s = compute_scale_perfly(data['X'][..., idx, flynum])
-            if scale_perfly is None:
-                scale_perfly = np.zeros((s.size, maxid + 1))
-                scale_perfly[:] = np.nan
-            else:
-                assert (np.all(np.isnan(scale_perfly[:, id])))
-            scale_perfly[:, id] = s.flatten()
-
-    return scale_perfly

--- a/notebooks/debug_fly_llm.py
+++ b/notebooks/debug_fly_llm.py
@@ -54,17 +54,6 @@ torch.cuda.is_available()
 # %load_ext autoreload
 # %autoreload 2
 
-
-
-# +
-agent_type='fly'
-
-tmp1 = r'fly(.*)_epoch\d+_(\d{8}T\d{6})'
-
-tmp2 = '(.*)_epoch\d+_(\d{8}T\d{6})'
-
-# tmp1 == tmp2
-
 # -
 
 # ## Load data

--- a/notebooks/debug_fly_llm.py
+++ b/notebooks/debug_fly_llm.py
@@ -33,9 +33,9 @@ from apf.models import (
     sanity_check_temporal_dep,
     criterion_wrapper,
 )
-from flyllm.io import read_config, get_modeltype_str, load_and_filter_data
-from flyllm.config import scalenames, nfeatures
-from flyllm.features import compute_features, sanity_check_tspred
+from apf.io import read_config, get_modeltype_str, load_and_filter_data
+from flyllm.config import scalenames, nfeatures, DEFAULTCONFIGFILE, featglobal, posenames
+from flyllm.features import compute_features, sanity_check_tspred, get_sensory_feature_idx
 from flyllm.dataset import FlyMLMDataset
 from flyllm.plotting import (
     initialize_debug_plots, 
@@ -54,13 +54,31 @@ torch.cuda.is_available()
 # %load_ext autoreload
 # %autoreload 2
 
+
+
+# +
+agent_type='fly'
+
+tmp1 = r'fly(.*)_epoch\d+_(\d{8}T\d{6})'
+
+tmp2 = '(.*)_epoch\d+_(\d{8}T\d{6})'
+
+# tmp1 == tmp2
+
+# -
+
 # ## Load data
 
 # +
 # configuration parameters for this model
 loadmodelfile = None
 restartmodelfile = None
-config = read_config("/groups/branson/home/eyjolfsdottire/code/MABe2022/config_fly_llm_multitimeglob_discrete_20230907.json")
+configfile = "/groups/branson/home/eyjolfsdottire/code/MABe2022/config_fly_llm_multitimeglob_discrete_20230907.json"
+config = read_config(configfile,
+                     default_configfile=DEFAULTCONFIGFILE,
+                     get_sensory_feature_idx=get_sensory_feature_idx,
+                     featglobal=featglobal,
+                     posenames=posenames)
 
 print(f"batch size = {config['batch_size']}")
 
@@ -413,12 +431,7 @@ for epoch in range(epoch, config['num_train_epochs']):
         X = chunk_data(data,config['contextl'],reparamfun,**chunk_data_params)
       
         train_dataset = FlyMLMDataset(X,**train_dataset_params,**dataset_params)
-        print('New training data set created')
-    
-    if (epoch+1)%config['save_epoch'] == 0:
-        savefile = os.path.join(config['savedir'],f"fly{modeltype_str}_epoch{epoch+1}_{savetime}.pth")
-        print(f'Saving to file {savefile}')
-        save_model(savefile,model,lr_optimizer=optimizer,scheduler=lr_scheduler,loss=loss_epoch,config=config)
+        print('New training data set created'))
 
 print('Done training')
 # -

--- a/tests/flyllm/generate_test_data.py
+++ b/tests/flyllm/generate_test_data.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 
 from apf.data import load_raw_npz_data, debug_less_data
-from flyllm.io import json_load_helper
+from apf.io import json_load_helper
 
 
 def make_test_data() -> str:


### PR DESCRIPTION
I had to refactor some of the functions to make them not depend on flyllm. This refactor makes calling `read_config` and `load_and_filter` data a bit annoying because you need to supply things like `compute_scale_perfly` and `keypointnames`. 

I think it would be good to refactor those functions again in the future to be more agnostic to the specific data, e.g. by handling missing fields in functions that wrap around these in each application, or by storing things necessary to load these as metainfo with the model/data.